### PR TITLE
Support unescaping of variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,11 @@ function compile(str) {
           assertProperty(tok);
           js.push(' + section(obj, "' + tok + '", false, ');
           break;
+        case '&':
+          tok = tok.slice(1);
+          assertProperty(tok);
+          js.push(' + obj.' + tok + ' + ');
+          break;
         default:
           assertProperty(tok);
           js.push(' + escape(obj.' + tok + ') + ');

--- a/test/index.js
+++ b/test/index.js
@@ -106,3 +106,10 @@ describe('{{^id}}', function(){
     mm('{{^admin}}{{^authenticated}}nope{{/}}{{/}}', user).should.equal('nope');
   })
 })
+
+describe('{{&id}}', function(){
+  it('should not escape', function(){
+    var user = { name: '<script>' };
+    mm('hi {{&name}}.', user).should.equal('hi <script>.');
+  })
+})


### PR DESCRIPTION
Implements support for unescaping variables with mustache's alternative {{&var}} syntax. The triple mustache ({{{var}}}) syntax is not implemented to keep the tokenizer simple.
