### PR TITLE
Added support for inverted sections and arrays. Fixes #14

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,13 @@ function indent(str) {
 
 function section(obj, prop, negate, thunk) {
   var val = obj[prop];
-  if (Array.isArray(val)) return val.map(thunk).join('');
+  if (Array.isArray(val)) {
+    if (negate) {
+      return val.length ? '' : thunk(obj);
+    } else {
+      return val.map(thunk).join('');
+    }
+  }
   if ('function' == typeof val) return val.call(obj, thunk(obj));
   if (negate) val = !val;
   if (val) return thunk(obj);

--- a/test/index.js
+++ b/test/index.js
@@ -118,4 +118,16 @@ describe('{{^id}}', function(){
     var user = { admin: false, authenticated: false };
     mm('{{^admin}}{{^authenticated}}nope{{/}}{{/}}', user).should.equal('nope');
   })
+
+  it('should consider empty arrays falsy', function(){
+    var users = { users: [] };
+    mm('users exist: {{^users}}nope{{/users}}', users)
+     .should.equal('users exist: nope');
+  })
+
+  it('should ignore populated arrays', function(){
+    var users = { users: [ 'tobi' ] };
+    mm('users exist: {{#users}}yep{{/users}}{{^users}}nope{{/users}}', users)
+     .should.equal('users exist: yep');
+  })
 })


### PR DESCRIPTION
As discovered in #14, we are being inconsistent with inverted sections and arrays. In this PR:
- Add tests against inverted sections and arrays
- Add support for considering empty arrays to be falsy
