### PR TITLE
don't crash with Windows line endings

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ function compile(str) {
   js = '\n'
     + indent(escape.toString()) + ';\n\n'
     + indent(section.toString()) + ';\n\n'
-    + '  return ' + js.join('').replace(/\n/g, '\\n');
+    + '  return ' + js.join('').replace(/\r?\n/g, '\\n');
 
   return new Function('obj', js);
 }


### PR DESCRIPTION
i've found a error when trying to compile a template with windows line endings

![image](https://cloud.githubusercontent.com/assets/4262050/14799012/fd7cc0d2-0aff-11e6-9a31-78fd45f828a4.png)

this PR fix the issue
